### PR TITLE
Cleaned up views for better readability, removed unnecessary compile action from dependencies.

### DIFF
--- a/AnyPhone-Android/AnyPhone/app/build.gradle
+++ b/AnyPhone-Android/AnyPhone/app/build.gradle
@@ -22,6 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.2.0'
-    compile fileTree(dir: 'libs', include: 'Parse-*.jar')
     compile 'com.parse.bolts:bolts-android:1.+'
 }

--- a/AnyPhone-Android/AnyPhone/app/src/main/java/com/parse/anyphone/MainActivity.java
+++ b/AnyPhone-Android/AnyPhone/app/src/main/java/com/parse/anyphone/MainActivity.java
@@ -10,7 +10,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Switch;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import com.parse.LogOutCallback;
@@ -21,24 +20,20 @@ import com.parse.SaveCallback;
 
 public class MainActivity extends AppCompatActivity {
     ParseUser user = ParseUser.getCurrentUser();
-    private TextView phoneNumberLabel, nameLabel;
-    private EditText nameField, phoneNumberField;
-    private Button saveSettingsButton;
+    private EditText nameField;
     private Switch setting1, setting2, setting3;
-    private Toolbar mToolbar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
-
+        Toolbar mToolbar = (Toolbar) findViewById(R.id.toolbar);
 
         setSupportActionBar(mToolbar);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
 
-        phoneNumberField = (EditText) findViewById(R.id.phoneNumberField);
+        EditText phoneNumberField = (EditText) findViewById(R.id.phoneNumberField);
         phoneNumberField.setText(LoginActivity.phoneNumber);
         nameField = (EditText) findViewById(R.id.nameField);
 
@@ -46,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
         setting2 = (Switch) findViewById(R.id.setting2);
         setting3 = (Switch) findViewById(R.id.setting3);
 
-        saveSettingsButton = (Button) findViewById(R.id.saveSettingsButton);
+        Button saveSettingsButton = (Button) findViewById(R.id.saveSettingsButton);
         saveSettingsButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -54,19 +49,20 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        if(!ParseUser.getCurrentUser().isNew())
+        if (!ParseUser.getCurrentUser().isNew())
             checkSettings();
 
-
     }
-    private  void checkSettings(){
-        nameField.setText(user.get("name").toString());
+
+    private void checkSettings() {
+        nameField.setText(user.getString("name"));
         setting1.setChecked(user.getBoolean("setting1"));
         setting2.setChecked(user.getBoolean("setting2"));
         setting2.setChecked(user.getBoolean("setting3"));
     }
+
     private void saveSettings() {
-        if(nameField != null) {
+        if (nameField != null) {
             user.put("name", nameField.getText().toString());
 
             if (setting1.isChecked()) {
@@ -86,13 +82,13 @@ public class MainActivity extends AppCompatActivity {
                             Toast.LENGTH_SHORT).show();
                 }
             });
-        }else{
+        } else {
             Toast.makeText(getApplicationContext(), "Please enter a username.",
                     Toast.LENGTH_SHORT).show();
         }
     }
 
-    private void logout (){
+    private void logout() {
         user.logOutInBackground(new LogOutCallback() {
             @Override
             public void done(ParseException e) {

--- a/AnyPhone-Android/AnyPhone/app/src/main/res/layout/activity_main.xml
+++ b/AnyPhone-Android/AnyPhone/app/src/main/res/layout/activity_main.xml
@@ -1,143 +1,143 @@
-<android.support.v4.widget.DrawerLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context=".MainActivity">
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-        <LinearLayout
-            android:id="@+id/container_toolbar"
-            android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <include
+            android:id="@+id/toolbar"
+            layout="@layout/toobar" />
+
+        <TextView
+            android:id="@+id/nameLabel"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_below="@+id/toolbar"
+            android:layout_marginLeft="25dp"
+            android:layout_marginStart="25dp"
+            android:layout_marginTop="15dp"
+            android:text="YOUR NUMBER"
+            android:textColor="@color/Grey" />
 
-            <include
-                android:id="@+id/toolbar"
-                layout="@layout/toobar" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:orientation="vertical"
+        <EditText
+            android:id="@+id/phoneNumberField"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="50dp"
+            android:layout_below="@+id/nameLabel"
+            android:layout_marginTop="5dp"
+            android:background="@color/colorPrimaryLight"
+            android:drawableEnd="@drawable/lock"
+            android:drawableRight="@drawable/lock"
+            android:ems="10"
+            android:hint="@string/number_default"
+            android:inputType="phone"
+            android:paddingEnd="35dp"
+            android:paddingLeft="25dp"
+            android:paddingRight="35dp"
+            android:paddingStart="25dp"
+            android:textColor="@color/colorPrimaryDark"
+            android:textColorHint="@color/LightGrey" />
+
+        <TextView
+            android:id="@+id/questionLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/phoneNumberField"
+            android:layout_marginLeft="25dp"
+            android:layout_marginTop="15dp"
+            android:text="YOUR NAME"
+            android:textColor="@color/Grey" />
+
+        <EditText
+            android:id="@+id/nameField"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_below="@+id/questionLabel"
+            android:layout_marginTop="5dp"
+            android:background="@color/colorPrimaryLight"
+            android:ems="10"
+            android:hint="Nick Fury"
+            android:paddingLeft="25dp"
+            android:textColor="@color/colorPrimaryDark"
+            android:textColorHint="@color/LightGrey" />
+
+        <TextView
+            android:id="@+id/settingsLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/nameField"
+            android:layout_marginLeft="25dp"
+            android:layout_marginTop="15dp"
+            android:text="SETTINGS"
+            android:textColor="@color/Grey" />
+
+        <Switch
+            android:id="@+id/setting1"
+            android:layout_width="match_parent"
+            android:layout_height="70dp"
+            android:layout_below="@+id/settingsLabel"
+            android:layout_gravity="center_horizontal"
+            android:background="@color/colorPrimaryLight"
+            android:paddingLeft="25dp"
+            android:text="Orbital Tracking Grid"
+            android:textColor="@color/colorPrimaryDark" />
+
+        <View
+            android:id="@+id/divider1"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/setting1"
+            android:background="@color/dividerColor" />
+
+        <Switch
+            android:id="@+id/setting2"
+            android:layout_width="match_parent"
+            android:layout_height="70dp"
+            android:layout_below="@+id/divider1"
+            android:layout_gravity="center_horizontal"
+            android:background="@color/colorPrimaryLight"
+            android:paddingLeft="25dp"
+            android:text="Iron Legion"
+            android:textColor="@color/colorPrimaryDark" />
+
+        <View
+            android:id="@+id/divider2"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/setting2"
+            android:background="@color/dividerColor" />
+
+        <Switch
+            android:id="@+id/setting3"
+            android:layout_width="match_parent"
+            android:layout_height="70dp"
+            android:layout_below="@+id/divider2"
+            android:layout_gravity="center_horizontal"
+            android:background="@color/colorPrimaryLight"
+            android:paddingLeft="25dp"
+            android:text="Theta Protocol"
+            android:textColor="@color/colorPrimaryDark" />
+
+        <Button
+            android:id="@+id/saveSettingsButton"
+            android:layout_width="325dp"
+            android:layout_height="60dp"
+            android:layout_below="@+id/setting3"
             android:layout_centerHorizontal="true"
-            android:layout_below="@+id/linearLayout">
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="10dp"
+            android:background="@color/colorPrimaryDark"
+            android:text="Save Settings"
+            android:textAllCaps="false"
+            android:textColor="@color/icons"
+            android:textSize="20dp" />
 
-            <TextView
-                android:layout_marginTop="15dp"
-                android:layout_marginLeft="25dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="YOUR NUMBER"
-                android:id="@+id/nameLabel"
-                android:textColor="@color/Grey"/>
-            <EditText
-
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:layout_marginTop="5dp"
-                android:inputType="phone"
-                android:ems="10"
-                android:id="@+id/phoneNumberField"
-                android:hint="@string/number_default"
-                android:textColorHint="@color/LightGrey"
-                android:paddingLeft="25dp"
-                android:paddingRight="35dp"
-                android:background="@color/colorPrimaryLight"
-                android:textColor="@color/colorPrimaryDark"
-                android:drawableRight="@drawable/lock"/>
-
-            <TextView
-                android:layout_marginTop="15dp"
-                android:layout_marginLeft="25dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="YOUR NAME"
-                android:id="@+id/questionLabel"
-                android:textColor="@color/Grey"/>
-
-            <EditText
-                android:layout_marginTop="5dp"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:ems="10"
-                android:id="@+id/nameField"
-                android:hint="Nick Fury"
-                android:textColorHint="@color/LightGrey"
-                android:paddingLeft="25dp"
-                android:background="@color/colorPrimaryLight"
-                android:textColor="@color/colorPrimaryDark" />
-
-            <TextView
-                android:layout_marginTop="15dp"
-                android:layout_marginLeft="25dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="SETTINGS"
-                android:id="@+id/settingsLabel"
-                android:textColor="@color/Grey"/>
-
-
-            <Switch
-                android:layout_width="match_parent"
-                android:layout_height="70dp"
-                android:paddingLeft="25dp"
-                android:text="Orbital Tracking Grid"
-                android:background="@color/colorPrimaryLight"
-                android:id="@+id/setting1"
-                android:layout_gravity="center_horizontal"
-                android:textColor="@color/colorPrimaryDark"/>
-
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="1dp"
-                android:background="@color/dividerColor"/>
-
-            <Switch
-                android:layout_width="match_parent"
-                android:layout_height="70dp"
-                android:paddingLeft="25dp"
-                android:text="Iron Legion"
-                android:background="@color/colorPrimaryLight"
-                android:id="@+id/setting2"
-                android:layout_gravity="center_horizontal"
-                android:textColor="@color/colorPrimaryDark"/>
-
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="1dp"
-                android:background="@color/dividerColor"/>
-
-            <Switch
-                android:layout_width="match_parent"
-                android:layout_height="70dp"
-                android:paddingLeft="25dp"
-                android:text="Theta Protocol"
-                android:background="@color/colorPrimaryLight"
-                android:id="@+id/setting3"
-                android:layout_gravity="center_horizontal"
-                android:textColor="@color/colorPrimaryDark"/>
-
-            <Button
-                android:layout_width="325dp"
-                android:layout_height="60dp"
-                android:layout_marginTop="10dp"
-                android:textSize="20dp"
-                android:textAllCaps="false"
-                android:text="Save Settings"
-                android:id="@+id/saveSettingsButton"
-                android:background="@color/colorPrimaryDark"
-                android:textColor="@color/icons"
-                android:layout_gravity="center_horizontal" />
-
-        </LinearLayout>
-
-    </LinearLayout>
+    </RelativeLayout>
 
 
 </android.support.v4.widget.DrawerLayout>

--- a/AnyPhone-Android/AnyPhone/app/src/main/res/layout/activity_splash.xml
+++ b/AnyPhone-Android/AnyPhone/app/src/main/res/layout/activity_splash.xml
@@ -16,6 +16,7 @@
         android:textAppearance="?android:attr/textAppearanceLarge"
         android:text="@string/app_name"
         android:textSize="50dp"
+        android:textColor="?attr/colorPrimary"
         android:id="@+id/app_name"
         android:layout_marginTop="175dp"
         android:layout_alignParentTop="true"


### PR DESCRIPTION
9018931: In gradle dependencies we have by default  compile fileTree(dir: 'libs', include: ['*.jar']) 
no need to tell gradle to compile fileTree(dir: 'libs', include: 'Parse-*.jar')

1fba1d3: Cleaned up the MainActivity class so users don't get lost with the un-used views.

069043d: There were too many chained LinearLayout, a single RelativeLayout makes it cleaner and easier to follow. There were some fill_parent tags which are deprecated, changed them to match_parent instead.

8334c71: Just applied the primary color to the splash so its cooler :-) 