### PR TITLE
Send code via SMS on user's first access.

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -44,6 +44,7 @@ Parse.Cloud.define("sendCode", function(req, res) {
 			user.set("language", language);
 			user.setACL({}); 
 			user.save().then(function(a) {
+				return sendCodeSms(phoneNumber, num, language);
 			}).then(function() {
 				res.success();
 			}, function(err) {


### PR DESCRIPTION
This code existed before but was removed in commit 4c35e1b972481a2c8d739ae12c721fc6bcfa1404 which broke the web app on user's first access.