### PR TITLE
Cleanup code from inferred types.

### DIFF
--- a/AnyPhone/AnyPhone/MainViewController.swift
+++ b/AnyPhone/AnyPhone/MainViewController.swift
@@ -43,7 +43,7 @@ class MainViewController: UIViewController {
   }
 
   @IBAction func didTapLogOut(sender: AnyObject) {
-    PFUser.logOutInBackgroundWithBlock { (error: NSError?) -> Void in
+    PFUser.logOutInBackgroundWithBlock { error in
       self.dismissViewControllerAnimated(true, completion: nil)
     }
   }


### PR DESCRIPTION
Learned couple new tricks - applying them in practice.

P.S. Not sure if removing the type annotations from closure arguments is worth doing, since the previous state provided more context on the types, but this is waay cleaner.
@gfosco Leave the type annotations and get rid of `-> Void` only or this looks better?