### PR TITLE
Fixed issue where sendCode returns undefined on success

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -33,7 +33,7 @@ Parse.Cloud.define("sendCode", function(req, res) {
 			result.save().then(function() {
 				return sendCodeSms(phoneNumber, num, language);
 			}).then(function() {
-				res.success();
+				res.success({});
 			}, function(err) {
 				res.error(err);
 			});
@@ -46,7 +46,7 @@ Parse.Cloud.define("sendCode", function(req, res) {
 			user.save().then(function(a) {
 				return sendCodeSms(phoneNumber, num, language);
 			}).then(function() {
-				res.success();
+				res.success({});
 			}, function(err) {
 				res.error(err);
 			});


### PR DESCRIPTION
Parse.Cloud.run seems to require a response object in order for the success callback. Without it, you get.

```
I2016-01-02T21:52:45.586Z]v11 Ran cloud function sendCode with:
  Input: {"language":"en","phoneNumber":"07590609702"}
  Result: undefined
I2016-01-02T21:52:47.031Z]{"0":{"code":107,"message":"The server returned an invalid response."}}
```